### PR TITLE
Check if device is an iPad on safari

### DIFF
--- a/lib/helpers/isDevice.js
+++ b/lib/helpers/isDevice.js
@@ -18,6 +18,13 @@ const IsDevice = (() => {
     iOS() {
       return ua.match(/iPhone|iPad|iPod/i)
     },
+    iPad() {
+       return (
+          ua.match(/Mac/) &&
+          navigator.maxTouchPoints &&
+          navigator.maxTouchPoints > 2
+       )
+    },
     OperaMini() {
       return ua.match(/Opera Mini/i)
     },
@@ -30,6 +37,7 @@ const IsDevice = (() => {
         IsDevice.Android() ||
         IsDevice.BlackBerry() ||
         IsDevice.iOS() ||
+        IsDevice.iPad() ||
         IsDevice.OperaMini() ||
         IsDevice.IEMobile()
       )


### PR DESCRIPTION
Unfortunately the latest iPad safari browser uses the same machintosh user agent. 
So to verify correctly if it's an iPad we add an extra check on the touchscreen; the iPad is the only one apple device wich use the mac User Agent and wich also has the touch screen events enabled.