### PR TITLE
Spelling correction: showSystemCursir to showSystemCursor in ReadMe.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ table th:nth-of-type(4) {
 | `outerScale` | number | amount outer dot scales on click or link hover  | `5`  |
 | `outerSize`  | number | Size (px) of outer cursor outline  | `8` |
 | `outerStyle` | object | provides custom styles / css to outer cursor  | `null` |
-| `showSystemCursir` | boolean | Show system/brower cursor | `false` |
+| `showSystemCursor` | boolean | Show system/brower cursor | `false` |
 | `trailingSpeed` | number | Outer dot's trailing speed | `8` |
 
 <br/>


### PR DESCRIPTION
This commit addresses a minor spelling error in the codebase. The props "showSystemCursir" has been updated to "showSystemCursor" to ensure consistent and accurate naming conventions throughout the project.

The correction was made in [readme.md](https://github.com/stephenscaff/react-animated-cursor/blob/master/readme.md) to align with the intended functionality of displaying the system cursor.

By rectifying this spelling mistake, we enhance the clarity and maintainability of the codebase. The commit contributes to the overall quality and professionalism of the project, promoting better collaboration and understanding among developers.

Please review the changes made in this commit to validate the correctness of the correction. Your feedback and suggestions are greatly appreciated. Once approved, these changes will be merged into the main codebase to ensure that future implementations utilize the accurate function name.

Thank you for your attention to detail and continuous support in maintaining the codebase's integrity.

Affected Files:
[readme.md](https://github.com/stephenscaff/react-animated-cursor/blob/master/readme.md)