### PR TITLE
Add React 19 to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.1.0",
+        "react-dom": "^18.2.0 || ^19.1.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "url": "https://github.com/stephenscaff/react-animated-cursor/issues"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.1.0",
+    "react-dom": "^18.2.0 || ^19.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",


### PR DESCRIPTION
Added React 19 to peer dependencies so that `--force` or `--legacy-peer-deps` doesn't have to be used when installing this library to a React 19 project.